### PR TITLE
Suricata関連の修正

### DIFF
--- a/osect_sensor/Application/edge_cron/common/common_config.py
+++ b/osect_sensor/Application/edge_cron/common/common_config.py
@@ -75,11 +75,5 @@ PCAP_COMPLETE_ARCHIVES_DELETE_LIMIT_CAPACITY = 250
 CLIENT_CERTIFICATE_PATH = '/etc/ssl/private/client.pem'
 """クライアント認証のための証明書・秘密鍵"""
 
-ALLOWABLE_DELAY_TIME = 3600
-"""センサーから送られるログの許容遅延時間（秒）"""
-
-SURICATA_SIGNATURE_VERSION_URL = 'https://rules.emergingthreats.net/open/suricata-6.0.4/version.txt'
-"""Suricataのシグネチャのバージョン数を取得するURL"""
-
 SEND_VERSION_API_URL = 'https://your url/paper/api/v1/sensor_status/post'
 """Suricataシグネチャのバージョンを送るURL"""

--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -236,7 +236,7 @@ RUN apt-get update && apt-get install -y suricata
 RUN wget http://rules.emergingthreats.net/open/suricata-6.0/emerging.rules.tar.gz \
  && tar -xzvf emerging.rules.tar.gz \
  && mkdir -p /var/lib/suricata/rules \
- && rm rules/*ja3.rules
+ && rm rules/*ja3.rules \
  && grep -h -ve "^#" -ve "^$" rules/*.rules > /var/lib/suricata/rules/suricata.rules
 
 # suricata

--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -229,13 +229,14 @@ RUN cd /home/work/ot_tools/ && tar xvzf yaf-2.11.0.tar.gz
 RUN cd /home/work/ot_tools/yaf-2.11.0/ && ./configure && make && make install && ldconfig
 
 # suricata
-RUN add-apt-repository ppa:oisf/suricata-stable
+RUN add-apt-repository ppa:oisf/suricata-6.0
 RUN apt-get update && apt-get install -y suricata
 
 # suricata rules
-RUN wget http://rules.emergingthreats.net/open/suricata-6.0.4/emerging.rules.tar.gz \
+RUN wget http://rules.emergingthreats.net/open/suricata-6.0/emerging.rules.tar.gz \
  && tar -xzvf emerging.rules.tar.gz \
  && mkdir -p /var/lib/suricata/rules \
+ && rm rules/*ja3.rules
  && grep -h -ve "^#" -ve "^$" rules/*.rules > /var/lib/suricata/rules/suricata.rules
 
 # suricata

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata.yaml
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata.yaml
@@ -833,7 +833,7 @@ app-layer:
       # If the limit is reached, app-layer-event:modbus.flooded; will match.
       #request-flood: 500
 
-      enabled: no
+      enabled: yes
       detection-ports:
         dp: 502
       # According to MODBUS Messaging on TCP/IP Implementation Guide V1.0b, it
@@ -847,13 +847,13 @@ app-layer:
 
     # DNP3
     dnp3:
-      enabled: no
+      enabled: yes
       detection-ports:
         dp: 20000
 
     # SCADA EtherNet/IP and CIP protocol support
     enip:
-      enabled: no
+      enabled: yes
       detection-ports:
         dp: 44818
         sp: 44818
@@ -862,6 +862,36 @@ app-layer:
     # with --enable-rust-experimental passed to configure
     ntp:
       enabled: no
+
+    tftp:
+      enabled: yes
+
+    ikev2:
+      enabled: yes
+
+    krb5:
+      enabled: yes
+
+    dhcp:
+      enabled: yes
+
+    snmp:
+      enabled: yes
+
+    sip:
+      enabled: yes
+
+    rfb:
+      enabled: yes
+
+    mqtt:
+      enabled: yes
+
+    rdp:
+      enabled: yes
+
+    http2:
+      enabled: yes
 
 # Limit for the maximum number of asn1 frames to decode (default 256)
 asn1-max-frames: 256

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata_update.sh
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata_update.sh
@@ -5,7 +5,7 @@ source /opt/ot_tools/proxy_env.txt
 source /etc/suricata_update.conf
 
 if [ -z "$DOWNLOAD_URL_PREFIX"]; then
-    DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0.4/
+    DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0/
 fi
 
 if [ -z "$DOWNLOAD_SIG_FILE"]; then
@@ -71,7 +71,7 @@ fi
 # Extract signature rules
 rm -rf rules
 tar -xzf $DOWNLOAD_SIG_FILE
-rm rules/emerging-ja3.rules
+rm rules/*ja3.rules
 grep -h -ve "^#" -ve "^$" rules/*.rules > /var/lib/suricata/rules/suricata.rules
 mv $DOWNLOAD_VER_FILE current_version
 

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata_update.sh
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/suricata_update.sh
@@ -2,11 +2,22 @@
 
 source /opt/ot_tools/proxy_env.txt
 
-SURICATA_VERSION=`suricata -V | grep -o "[0-9]\.[0-9]\.[0-9]"`
+source /etc/suricata_update.conf
+
+if [ -z "$DOWNLOAD_URL_PREFIX"]; then
+    DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0.4/
+fi
+
+if [ -z "$DOWNLOAD_SIG_FILE"]; then
+    DOWNLOAD_SIG_FILE=emerging.rules.tar.gz
+fi
+
+if [ -z "$DOWNLOAD_VER_FILE"]; then
+    DOWNLOAD_VER_FILE=version.txt
+fi
+
+SURICATA_VERSION=`suricata -V | grep -o "[0-9]\.[0-9]\.[0-9]"`-${DOWNLOAD_SIG_FILE}
 export SURICATA_VERSION
-DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-${SURICATA_VERSION}/
-DOWNLOAD_SIG_FILE=emerging.rules.tar.gz
-DOWNLOAD_VER_FILE=version.txt
 
 cd /home/work/ || exit
 

--- a/osect_sensor/conf/suricata_update.conf
+++ b/osect_sensor/conf/suricata_update.conf
@@ -1,5 +1,5 @@
 # ルールダウンロード先のURL
-DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0.4/
+DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0/
 
 # ダウンロードするルールのファイル名
 DOWNLOAD_SIG_FILE=emerging.rules.tar.gz

--- a/osect_sensor/conf/suricata_update.conf
+++ b/osect_sensor/conf/suricata_update.conf
@@ -1,0 +1,8 @@
+# ルールダウンロード先のURL
+DOWNLOAD_URL_PREFIX=https://rules.emergingthreats.net/open/suricata-6.0.4/
+
+# ダウンロードするルールのファイル名
+DOWNLOAD_SIG_FILE=emerging.rules.tar.gz
+
+# ルールのバージョン数が記載されたファイル名
+DOWNLOAD_VER_FILE=version.txt

--- a/osect_sensor/docker-compose.yml
+++ b/osect_sensor/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - pcap-logs-volume:/opt/edge_cron/paper/sc_src/input/pcap/complete/
       - logs-volume:/var/log/ot_tools/
       - ./keys/client.pem:/etc/ssl/private/client.pem
+      - ./conf/suricata_update.conf:/etc/suricata_update.conf
     networks:
       edge-network:
         ipv4_address: 172.24.0.6


### PR DESCRIPTION
- #42
  - Suricataのルール取得先等を別ファイルで設定
    - `suricata_update.conf`ファイルとして追加し`/etc/`にマウント
  - 取得するルールファイル名も合わせて送信
- #44 
  - 6.0を指定するよう修正
- #45
  - 無効化されていたICS系のプロトコル（modbus, dnp3, enip）を有効化
  - suricata.yamlに記載していなかったプロトコルを明示的に有効化するよう設定を追記
- 不要な設定項目削除