### PR TITLE
#91 脆弱性対応

### DIFF
--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -255,5 +255,5 @@ RUN zkg autoconfig && zkg install --force --skiptest \
     zeek-plugin-profinet \
     zeek-plugin-s7comm \
     icsnpp-ethercat \
-    icsnpp-opcua-binary \
+    # icsnpp-opcua-binary \
     icsnpp-modbus

--- a/osect_sensor/Infrastructure/edge_cron/work/requirements.txt
+++ b/osect_sensor/Infrastructure/edge_cron/work/requirements.txt
@@ -1,11 +1,11 @@
 asgiref==3.4.1
 cachetools==4.2.2
-certifi==2020.6.20
+certifi==2022.12.7
 charset-normalizer==2.0.9
 Django==3.2.16
 dpkt==1.9.2
 gitdb2==2.0.3
-gitpython==3.0.7
+GitPython==3.1.30
 google-auth==1.30.0
 idna==2.10
 meson==0.56.0
@@ -22,6 +22,5 @@ sqlparse==0.4.2
 tornado==6.1
 typing_extensions==4.0.1
 urllib3==1.26.6
-wheel==0.34.2
 zkg==2.12.0
 zstandard==0.18.0


### PR DESCRIPTION
certifi==2020.6.20 -> 2022.12.7 にアップ
gitpython==3.0.7 -> 3.1.30　にアップ
wheel　削除
zkg　icsnpp-opcua-binary　パッケージを削除
