### PR TITLE
幾つかのbug解消

### DIFF
--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/CIFS_B/CIFS_B.zeek
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/CIFS_B/CIFS_B.zeek
@@ -4,15 +4,15 @@ export {
 	redef enum Log::ID += { LOG };
 
 	type Info: record {
-		ts:		time   &log &optional;
-		SrcIP:	        addr   &log &optional;
-		SrcMAC:         string &log &optional;
-		ServerName:     string &log &optional;
-		OSVersion:      string &log &optional;
-		ServerType:     string &log &optional;
+		ts:		time &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		ServerName: string &log &optional;
+		OSVersion: string &log &optional;
+		ServerType: string &log &optional;
 		BrowserVersion: string &log &optional;
-		Signature:      string &log &optional;
-		HostComment:    string &log &optional;
+		Signature: string &log &optional;
+		HostComment: string &log &optional;
 
 
 		# Set to block number of final piece of data once received.
@@ -29,20 +29,24 @@ export {
 	                                    ["\xCF\x80"] = "stop",
 										};
 
+	global Cc: set[string] = { "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\x09", "\x0a", "\x0b"
+								, "\x0c", "\x0d", "\x0e", "\x0f", "\x10", "\x11", "\x12", "\x13", "\x14", "\x15", "\x16", "\x17"
+								, "\x18", "\x19", "\x1a", "\x1b", "\x1c", "\x1d", "\x1e", "\x1f", "\x7f"};
+
 	type AggregationData: record {
-		SrcIP:	        addr   &log &optional;
-		SrcMAC:         string &log &optional;
-		ServerName:     string &log &optional;
-		OSVersion:      string &log &optional;
-		ServerType:     string &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		ServerName: string &log &optional;
+		OSVersion: string &log &optional;
+		ServerType: string &log &optional;
 		BrowserVersion: string &log &optional;
-		Signature:      string &log &optional;
-		HostComment:    string &log &optional;
+		Signature: string &log &optional;
+		HostComment: string &log &optional;
 	};
 
 	type Ts_num: record {
 		ts_s:			time &log;
-		num: 			int  &log;
+		num: 			int &log;
 		ts_e: 			time &log &optional;
 	};
 
@@ -148,14 +152,14 @@ event zeek_init() &priority=5
 
 function find_string(s: string): string
 	{
-	local x = "\x00";
+	# local x = "\x00";
 	local res = "";
 
 	for ( c in s )
 		{
-		if ( c == x )
+		if ( c in Cc )
 			{
-			break;
+			next;
 			}
 		else
 			{
@@ -201,7 +205,15 @@ function del_0(s: string): string
 			break;
 			}
 		}
-	return s[i:];
+
+	if ( |s[i:]| == 0 )
+		{
+		return "0";
+		}
+	else
+		{
+		return s[i:];
+		}
 	}
 
 event CIFS::hostAnnouncement(
@@ -263,8 +275,8 @@ event CIFS::localMatserAnnouncement(
 # 集約 local debug用
 event zeek_done()
 	{
-	print "zeek_done()";
-	print res_aggregationData;
+	# print "zeek_done()";
+	# print res_aggregationData;
 	for ( i in res_aggregationData ){
 		# print i;
         # print res_aggregationData[i];

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/DHCPV6/dhcpv6.zeek
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/DHCPV6/dhcpv6.zeek
@@ -4,13 +4,13 @@ export {
 	redef enum Log::ID += { LOG };
 
 	type Info: record {
-		ts:		  time            &log &optional;
-		SrcIP:	          addr            &log &optional;
-		SrcMAC:           string          &log &optional;
-		Hostname:         string          &log &optional;
-		FingerPrint:      vector of count &log &optional;
-		EnterpriseNumber: count           &log &optional;
-		VendorClass:      string          &log &optional;
+		ts:		time &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Hostname: string &log &optional;
+		FingerPrint: vector of count &log &optional;
+		EnterpriseNumber: count &log &optional;
+		VendorClass: string &log &optional;
 
 		# Set to block number of final piece of data once received.
 		final_block: count &optional;
@@ -26,18 +26,22 @@ export {
 	                                    ["\xCF\x80"] = "stop",
 										};
 	
+	global Cc: set[string] = { "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07", "\x08", "\x09", "\x0a", "\x0b"
+								, "\x0c", "\x0d", "\x0e", "\x0f", "\x10", "\x11", "\x12", "\x13", "\x14", "\x15", "\x16", "\x17"
+								, "\x18", "\x19", "\x1a", "\x1b", "\x1c", "\x1d", "\x1e", "\x1f", "\x7f"};
+
 	type AggregationData: record {
-		SrcIP:	          addr            &log &optional;
-		SrcMAC:           string          &log &optional;
-		Hostname:         string          &log &optional;
-		FingerPrint:      vector of count &log &optional;
-		EnterpriseNumber: count           &log &optional;
-		VendorClass:      string          &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Hostname: string &log &optional;
+		FingerPrint: vector of count &log &optional;
+		EnterpriseNumber: count &log &optional;
+		VendorClass: string &log &optional;
 	};
 
 	type Ts_num: record {
 		ts_s:			time &log;
-		num: 			int  &log;
+		num: 			int &log;
 		ts_e: 			time &log &optional;
 	};
 
@@ -138,7 +142,7 @@ function del_hex(s: string): string
 	local res = "";
 	for ( c in s )
 		{
-		if ( c == "\x05" || c == "\x00" )
+		if ( c in Cc )
 			{
 			next;
 			}
@@ -156,10 +160,10 @@ event zeek_init() &priority=5
 	}
 
 type Options: record {
-	host_name:  string;
-	vendor:     string;
+	host_name: string;
+	vendor: string;
 	enterprise: count;
-	rq_code:    vector of count;
+	rq_code: vector of count;
 };
 
 event DHCPV6::message(c: connection, is_orig: bool, options: Options)
@@ -197,8 +201,8 @@ event DHCPV6::message(c: connection, is_orig: bool, options: Options)
 # 集約 local debug用
 event zeek_done()
 	{
-	print "zeek_done()";
-	print res_aggregationData;
+	# print "zeek_done()";
+	# print res_aggregationData;
 	for ( i in res_aggregationData ){
 		# print i;
         # print res_aggregationData[i];

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/NBNS/nbns.zeek
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/NBNS/nbns.zeek
@@ -4,12 +4,12 @@ export {
 	redef enum Log::ID += { LOG };
 
 	type Info: record {
-		ts:		time 	&log &optional;
-		SrcIP:		addr 	&log &optional;
-		SrcMAC: 	string 	&log &optional;
-		Name: 		string 	&log &optional;
-		TTL: 		count 	&log &optional;
-		ServiceType: 	string 	&log &optional;
+		ts:		time &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Name: string &log &optional;
+		TTL: count &log &optional;
+		ServiceType: string &log &optional;
 
 		# Set to block number of final piece of data once received.
 		final_block: count &optional;
@@ -37,16 +37,16 @@ export {
 										};
 	
 	type AggregationData: record {
-		SrcIP:		addr 	&log &optional;
-		SrcMAC: 	string 	&log &optional;
-		Name: 		string 	&log &optional;
-		TTL: 		count 	&log &optional;
-		ServiceType: 	string 	&log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Name: string &log &optional;
+		TTL: count &log &optional;
+		ServiceType: string &log &optional;
 	};
 
 	type Ts_num: record {
 		ts_s:			time &log;
-		num: 			int  &log;
+		num: 			int &log;
 		ts_e: 			time &log &optional;
 	};
 
@@ -152,8 +152,8 @@ function half_to_full(queries_name: string): string
 		tmp1 = (bytestring_to_count(queries_name[i]) - 0x41) * 16;
 		tmp2 = (bytestring_to_count(queries_name[i + 1]) - 0x41) & 0xf;
 		tmp3 = fmt("%x", tmp1 | tmp2);
-		if (tmp3 == "0"){
-			res[|res|] = hexstr_to_bytestring("00");
+		if (|tmp3| == 1){
+			res[|res|] = hexstr_to_bytestring("0" + tmp3);
 		} else {
 			res[|res|] = hexstr_to_bytestring(tmp3);
 		}
@@ -202,8 +202,8 @@ event NBNS::message(c: connection, name_type: int, additional_records_ttl: count
 # 集約 local debug用
 event zeek_done()
 	{
-	print "zeek_done()";
-	print res_aggregationData;
+	# print "zeek_done()";
+	# print res_aggregationData;
 	for ( i in res_aggregationData ){
 		# print i;
         # print res_aggregationData[i];

--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/SSDP/ssdp.zeek
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/broscript/SSDP/ssdp.zeek
@@ -5,11 +5,11 @@ export {
 	redef ignore_checksums = T;
 
 	type Info: record {
-		ts:			time &log &optional;
-		SrcIP:			addr &log &optional;
-		SrcMAC: 		string &log &optional;
-		Method: 		string &log &optional;
-		SERVER_or_USER_AGENT: 	string &log &optional;
+		ts:		time &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Method: string &log &optional;
+		SERVER_or_USER_AGENT: string &log &optional;
 
 		# Set to block number of final piece of data once received.
 		final_block: count &optional;
@@ -22,15 +22,15 @@ export {
 	global log_ssdp: event(rec: Info);
 
 	type AggregationData: record {
-		SrcIP:			addr &log &optional;
-		SrcMAC: 		string &log &optional;
-		Method: 		string &log &optional;
-		SERVER_or_USER_AGENT: 	string &log &optional;
+		SrcIP:	addr &log &optional;
+		SrcMAC: string &log &optional;
+		Method: string &log &optional;
+		SERVER_or_USER_AGENT: string &log &optional;
 	};
 
 	type Ts_num: record {
 		ts_s:			time &log;
-		num: 			int  &log;
+		num: 			int &log;
 		ts_e: 			time &log &optional;
 	};
 
@@ -181,8 +181,8 @@ event SSDP::message(c: connection, method: string, line: Line)
 # 集約 local debug用
 event zeek_done()
 	{
-	print "zeek_done()";
-	print res_aggregationData;
+	# print "zeek_done()";
+	# print res_aggregationData;
 	for ( i in res_aggregationData ){
 		# print i;
         # print res_aggregationData[i];

--- a/osect_sensor/conf/local.zeek
+++ b/osect_sensor/conf/local.zeek
@@ -6,6 +6,7 @@
 # the creation of file IDs. Please change this to a hard to guess value.
 redef digest_salt = "Please change this value.";
 redef ignore_checksums = T;
+redef LogAscii::enable_utf_8 = F;
 
 # This script logs which scripts were loaded during each run.
 #@load misc/loaded-scripts


### PR DESCRIPTION
- mswin-browser.logのServerType欄が全て0の場合はlogに`0x`が出る問題
    - 上記の場合は`0x0`に変更
- netbios-ns.log作成時に時々`Hex string '3' has invalid length`が出る問題
    - hexstr_to_bytestring()関数の問題 → 渡す文字列の長さが1の場合に発生
    - 長さが1の時に前に`”0”`を追加
- dhcpv4のMACアドレスが正しく取れない問題
    - 他のzeekファイルのMACアドレスの取り方と違う方法で取ることで解決
        - info$SrcMAC = c$orig$l2_addr;（他のzeek）
        - info$SrcMAC = msg$chaddr;（dhcpv4）
- mswin-browser.logのServerNameが16進数が混入する場合は自動文字に変換される問題
    - 例：`\xd8\xb0`->`ذ`
    - `redef LogAscii::enable_utf_8 = F;`設定で解決
- 符号`\`が自動的に`\\`に変換される問題
    - 修正不要
- 上記の問題を修正し、アクセリア様のデータを500個程度でテストしました。 → 問題なし
    - 集約前のzeekのlog と dpktで生成したlogの比較 → 一致
    - 集約後のlogと集約前のlogの数を比較 → 一致