### PR TITLE
use git to clone zeek-parser-Bacnet

### DIFF
--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update \
     flex \
     kmod \
     gawk \
+    git \
     libmount-dev \
     libpcre3-dev \
     libyaml-dev \
@@ -75,6 +76,10 @@ RUN wget -q http://rules.emergingthreats.net/open/suricata-6.0/emerging.rules.ta
     && mkdir -p /var/lib/suricata/rules \
     && rm rules/*ja3.rules \
     && grep -h -ve "^#" -ve "^$" rules/*.rules > /var/lib/suricata/rules/suricata.rules
+
+# zeek-parser-Bacnetのclone
+WORKDIR /home/work
+RUN git clone https://github.com/nttcom/zeek-parser-Bacnet.git
 
 # 本番イメージ
 FROM zeek/zeek:5.0.0
@@ -157,6 +162,7 @@ RUN zkg install --force --skiptest \
 #    icsnpp-ethercat \
 #    icsnpp-opcua-binary \
     icsnpp-modbus \
+    icsnpp-bacnet \
     zeek/corelight/zeek-long-connections \
     zeek-af_packet-plugin
 
@@ -202,6 +208,8 @@ RUN cp -p ot_tools/broscript/CIFS_B/CIFS_B.hlto /usr/local/zeek/lib/zeek-spicy/m
 RUN mkdir /var/log/yaf
 COPY --from=build-env /usr/local/bin /usr/local/bin
 COPY --from=build-env /usr/local/lib /usr/local/lib
+# zeek-parser-Bacnetのコピー
+COPY --from=build-env /home/work/zeek-parser-Bacnet /home/work/zeek-parser-Bacnet
 
 # Suricataはほぼ無駄がないためそのままインストール
 # Suricata rulesをコピー
@@ -232,9 +240,10 @@ RUN mkdir /opt/ot_tools \
     && cp -p ot_tools/broscript/dns.zeek /usr/local/zeek/share/zeek/base/protocols/dns/main.zeek \
     && cp -p ot_tools/*.sh /opt/ot_tools/ \
     && cp -p ot_tools/yaf.awk /opt/ot_tools/ \
-    && cp -pr ot_tools/p0f /opt/ 
+    && cp -pr ot_tools/p0f /opt/ \
+    && cp -p zeek-parser-Bacnet/scripts/bacnet_ip.zeek /usr/local/zeek/share/zeek/site/icsnpp-bacnet/main.zeek \
+    && cp -p zeek-parser-Bacnet/scripts/consts_bacnet_ip.zeek /usr/local/zeek/lib/zeek/plugins/packages/icsnpp-bacnet/scripts/consts.zeek
 
 # 環境変数
 RUN printenv | grep -e https_proxy -e HTTPS_PROXY -e http_proxy -e HTTP_PROXY -e no_proxy -e NO_PROXY| awk '{print "export " $1}' > /opt/ot_tools/proxy_env.txt \
     && mv supervisord.conf /etc/supervisor/conf.d/
-


### PR DESCRIPTION
[zeek-parser-Bacnet](https://github.com/nttcom/zeek-parser-Bacnet )をgit cloneできるように、Dockerfileを書き換えました。

- buildが通ることのテスト：
```
sectu@sensor:~/osect_sensor/Infrastructure/edge_cron$ docker build -t bacnet-test-image .
[+] Building 0.7s (53/53) FINISHED                                                            docker:default
 => [internal] load .dockerignore                                                                       0.0s
 => => transferring context: 2B                                                                         0.0s
 => [internal] load build definition from Dockerfile                                                    0.0s
 => => transferring dockerfile: 8.86kB                                                                  0.0s
 => [internal] load metadata for docker.io/zeek/zeek:5.0.0                                              0.6s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                         0.6s
 => [internal] load build context                                                                       0.0s
 => => transferring context: 3.80kB                                                                     0.0s
 => [build-env  1/12] FROM docker.io/library/ubuntu:20.04@sha256:33a5cc25d22c45900796a1aca487ad7a7cb09  0.0s
 => [stage-1  1/35] FROM docker.io/zeek/zeek:5.0.0@sha256:1c0447a8e60cf177a15f368992e684f02b4d90b65ff1  0.0s
 => CACHED [stage-1  2/35] WORKDIR /home/work                                                           0.0s
 => CACHED [stage-1  3/35] COPY work/ /home/work                                                        0.0s
 => CACHED [stage-1  4/35] RUN mkdir /home/work/django && mkdir /home/work/uwsgi                        0.0s
 => CACHED [stage-1  5/35] RUN apt-get update && apt-get install -y --no-install-recommends     cron    0.0s
 => CACHED [stage-1  6/35] WORKDIR /home/work                                                           0.0s
 => CACHED [stage-1  7/35] RUN apt-get update     && apt-get purge -y python3-yaml     && python3.9 -m  0.0s
 => CACHED [stage-1  8/35] RUN zkg install --force --skiptest     icsnpp-modbus     icsnpp-bacnet       0.0s
 => CACHED [stage-1  9/35] WORKDIR /home/work/ot_tools/broscript/CIFS_B/                                0.0s
 => CACHED [stage-1 10/35] RUN spicyz -o CIFS_B.hlto CIFS_B.spicy CIFS_B.evt                            0.0s
 => CACHED [stage-1 11/35] WORKDIR /home/work/ot_tools/broscript/MYDHCP/                                0.0s
 => CACHED [stage-1 12/35] RUN spicyz -o MYDHCP.hlto MYDHCP.spicy zeek_MYDHCP.spicy MYDHCP.evt          0.0s
 => CACHED [stage-1 13/35] WORKDIR /home/work/ot_tools/broscript/DHCPV6/                                0.0s
 => CACHED [stage-1 14/35] RUN spicyz -o dhcpv6.hlto dhcpv6.spicy zeek_dhcpv6.spicy dhcpv6.evt          0.0s
 => CACHED [stage-1 15/35] WORKDIR /home/work/ot_tools/broscript/NBNS/                                  0.0s
 => CACHED [stage-1 16/35] RUN spicyz -o nbns.hlto nbns.spicy nbns.evt                                  0.0s
 => CACHED [stage-1 17/35] WORKDIR /home/work/ot_tools/broscript/SSDP/                                  0.0s
 => CACHED [stage-1 18/35] RUN spicyz -o ssdp.hlto ssdp.spicy ssdp.evt                                  0.0s
 => CACHED [stage-1 19/35] WORKDIR /home/work/ot_tools/broscript/CC_LINK_BASIC/                         0.0s
 => CACHED [stage-1 20/35] RUN spicyz -o cc_link_basic.hlto cc_link_basic.spicy cc_link_basic.evt       0.0s
 => CACHED [stage-1 21/35] WORKDIR /home/work/ot_tools/broscript/CC_LINK_NOIP/                          0.0s
 => CACHED [stage-1 22/35] RUN spicyz -o cc_link_noip.hlto cc_link_noip.spicy cc_link_noip.evt          0.0s
 => CACHED [stage-1 23/35] WORKDIR /home/work                                                           0.0s
 => CACHED [stage-1 24/35] RUN cp -p ot_tools/broscript/CIFS_B/CIFS_B.hlto /usr/local/zeek/lib/zeek-sp  0.0s
 => CACHED [stage-1 25/35] RUN mkdir /var/log/yaf                                                       0.0s
 => CACHED [build-env  2/12] WORKDIR /home/work                                                         0.0s
 => CACHED [build-env  3/12] COPY work/ /home/work                                                      0.0s
 => CACHED [build-env  4/12] RUN mkdir /home/work/django && mkdir /home/work/uwsgi                      0.0s
 => CACHED [build-env  5/12] RUN apt-get update  && apt-get install -y --no-install-recommends     bis  0.0s
 => CACHED [build-env  6/12] WORKDIR /home/work                                                         0.0s
 => CACHED [build-env  7/12] RUN apt-get purge -y python3-yaml     && python3.8 -m pip install --upgra  0.0s
 => CACHED [build-env  8/12] WORKDIR /home/work                                                         0.0s
 => CACHED [build-env  9/12] RUN wget -q https://download.gnome.org/sources/glib/2.60/glib-2.60.7.tar.  0.0s
 => CACHED [build-env 10/12] RUN wget -q http://rules.emergingthreats.net/open/suricata-6.0/emerging.r  0.0s
 => CACHED [build-env 11/12] WORKDIR /home/work                                                         0.0s
 => CACHED [build-env 12/12] RUN git clone https://github.com/nttcom/zeek-parser-Bacnet.git             0.0s
 => CACHED [stage-1 26/35] COPY --from=build-env /usr/local/bin /usr/local/bin                          0.0s
 => CACHED [stage-1 27/35] COPY --from=build-env /usr/local/lib /usr/local/lib                          0.0s
 => CACHED [stage-1 28/35] COPY --from=build-env /home/work/zeek-parser-Bacnet /home/work/zeek-parser-  0.0s
 => CACHED [stage-1 29/35] RUN mkdir -p /var/lib/suricata/rules                                         0.0s
 => CACHED [stage-1 30/35] COPY --from=build-env /var/lib/suricata/rules/suricata.rules /var/lib/suric  0.0s
 => CACHED [stage-1 31/35] WORKDIR /home/work                                                           0.0s
 => CACHED [stage-1 32/35] RUN apt-get update     &&  apt-get install -y --no-install-recommends suric  0.0s
 => CACHED [stage-1 33/35] WORKDIR /home/work                                                           0.0s
 => CACHED [stage-1 34/35] RUN mkdir /opt/ot_tools     && cp -p ot_tools/broscript/conn/__load__.zeek   0.0s
 => CACHED [stage-1 35/35] RUN printenv | grep -e https_proxy -e HTTPS_PROXY -e http_proxy -e HTTP_PRO  0.0s
 => exporting to image                                                                                  0.0s
 => => exporting layers                                                                                 0.0s
 => => writing image sha256:be853b90512109094793b05effe8ac00c3e13f16dc933a2e7c7819c98eb2db39            0.0s
 => => naming to docker.io/library/bacnet-test-image                                                    0.0s
```

- built imageの確認：
```
sectu@sensor:~/osect_sensor/Infrastructure/edge_cron$ docker images
REPOSITORY                                                                               TAG                               IMAGE ID       CREATED         SIZE
bacnet-test-image                                                                        latest                            be853b905121   4 minutes ago   2.56GB
```

- zeek-parser-Bacnetのscriptsは正しい場所にコピーされているかどうかの確認：
```
sectu@sensor:~/osect_sensor/Infrastructure/edge_cron$ docker run -it bacnet-test-image
root@f03f0c4206aa:/home/work# cd /usr/local/zeek/share/zeek/site/icsnpp-bacnet/
root@f03f0c4206aa:/usr/local/zeek/share/zeek/site/icsnpp-bacnet# ls
__load__.zeek  dpd.sig  files.zeek  main.zeek
root@f03f0c4206aa:/usr/local/zeek/share/zeek/site/icsnpp-bacnet# cat main.zeek
```

- センサーとして機能することを確認:
(ビルド後に、bacnet.logが出ていることを確認しました)
<img width="513" alt="Screenshot 2023-08-23 at 19 02 52" src="https://github.com/nttcom/OsecT/assets/57517810/e224b00f-0dbd-4a75-b62b-61598ba91736">
