### PR TITLE
add docker to user group & delete unnecessary lines

### DIFF
--- a/osect_sensor/README.md
+++ b/osect_sensor/README.md
@@ -43,7 +43,8 @@ Docker CEをインストールします。
 
 ```bash
 $ sudo apt install -y docker-ce
-$ sudo docker container run --rm hello-world
+# sudo usermod -aG docker <username>
+$ docker container run --rm hello-world
 ```
 
 docker-compose 1.27.4をインストールします。
@@ -167,8 +168,6 @@ DjangoのSECRET_KEYの設定を設定します。
 
 ```bash
 $ SK=`cat /dev/urandom | base64 | fold -w 64 | head -n 1`; sed -i -e 's@SECRET_KEY = ""@SECRET_KEY = "'$SK'"@g' ~/osect_sensor/Application/edge_cron/edge_cron/settings.py
-（何も表示されません。）
-$ SK=`cat /dev/urandom | base64 | fold -w 64 | head -n 1`; sed -i -e 's@SECRET_KEY = ""@SECRET_KEY = "'$SK'"@g' ~/osect_sensor/Application/edge_tcpdump/sc_tcpdump/settings.py
 （何も表示されません。）
 ```
 

--- a/osect_sensor/README.md
+++ b/osect_sensor/README.md
@@ -43,7 +43,7 @@ Docker CEをインストールします。
 
 ```bash
 $ sudo apt install -y docker-ce
-# sudo usermod -aG docker <username>
+$ sudo usermod -aG docker <username>
 $ docker container run --rm hello-world
 ```
 

--- a/osect_sensor/README.md
+++ b/osect_sensor/README.md
@@ -206,6 +206,6 @@ $ ~/osect_sensor/keys/client.pem
 
 ```bash
 $ cd ~/osect_sensor/
-$ sudo /usr/local/bin/docker-compose build
-$ sudo /usr/local/bin/docker-compose up -d
+$ /usr/local/bin/docker-compose build
+$ /usr/local/bin/docker-compose up -d
 ```


### PR DESCRIPTION
close #131 

- [x] ユーザーグループにdockerを加える
- [x] edge_tcpdumpの行を削除
- [x] sudo不要でビルドできるように変更

テストした結果：
```
sectu@sensor:~$ /usr/local/bin/docker-compose build
中略
Successfully built 7a50183aa581
Successfully tagged cron:revxxx
sectu@sensor:~/osect_sensor$ /usr/local/bin/docker-compose up -d
Recreating osect_sensor_edge_cron_1 ... done
```
通りました