### PR TITLE
fix bug when deleting log

### DIFF
--- a/osect_sensor/Infrastructure/edge_cron/work/ot_tools/bro.sh
+++ b/osect_sensor/Infrastructure/edge_cron/work/ot_tools/bro.sh
@@ -47,4 +47,4 @@ if [ $5 = "True" ]; then
     merge_log "modbus_detailed.*.log" "modbus_detailed.log"
 fi
 
-rm $(find /usr/local/zeek/logs -name "*.log")
+find /usr/local/zeek/logs -name "*.log" -print0 | xargs -0 rm


### PR DESCRIPTION
Close #142 

Argument list too longは通常、処理するファイルの数が多すぎるため、パラメータリストの長さがOSの制限を超えたためです。

OsecT20での検証：
1. rm $(find /usr/local/zeek/logs -name "*.log")をコメントアウトしました。
2. root@sensor:/usr/local/zeek/logs/2023-10-25# lsでlogがあることを確認しました。
```
bacnet.06:43:01-06:44:00.log              cclink-ie-tsn-slmp.06:47:00-06:48:00.log  notice.06:47:00-06:48:00.log
bacnet.06:45:00-06:46:00.log              cclink-ie-tsn-slmp.06:52:00-06:53:00.log  notice.06:48:00-06:49:00.log
bacnet.06:46:00-06:47:00.log              cclink-ie-tsn.06:42:00-06:43:00.log       notice.06:53:00-06:54:00.log
bacnet.06:47:00-06:48:00.log              cclink-ie-tsn.06:45:00-06:46:00.log       stats.06:15:00-06:16:00.log
bacnet.06:52:00-06:53:00.log              cclink-ie-tsn.06:46:00-06:47:00.log       stats.06:16:00-06:17:00.log
bacnet.06:53:00-06:54:00.log              cclink-ie-tsn.06:53:00-06:54:00.log       stats.06:20:00-06:21:00.log
broker.06:41:00-06:42:00.log              cclink-ie.06:44:00-06:45:00.log           stats.06:21:00-06:22:00.log
broker.06:42:00-06:43:00.log              cclink-ie.06:46:00-06:47:00.log           stats.06:25:00-06:26:00.log
broker.06:46:00-06:47:00.log              cclink-ief-basic.06:44:00-06:45:00.log    stats.06:26:00-06:27:00.log
broker.06:47:00-06:48:00.log              cluster.06:41:00-06:42:00.log             stats.06:30:00-06:31:00.log
broker.06:51:00-06:52:00.log              cluster.06:42:00-06:43:00.log             stats.06:31:00-06:32:00.log
broker.06:52:00-06:53:00.log              cluster.06:46:00-06:47:00.log             stats.06:35:00-06:36:00.log
capture_loss.06:17:00-06:18:00.log        cluster.06:47:00-06:48:00.log             stats.06:36:00-06:37:00.log
capture_loss.06:32:00-06:33:00.log        cluster.06:51:00-06:52:00.log             stats.06:40:00-06:41:00.log
capture_loss.06:43:00-06:44:00.log        cluster.06:52:00-06:53:00.log             stats.06:41:00-06:42:00.log
capture_loss.06:47:00-06:48:00.log        files.06:42:05-06:43:00.log               stats.06:45:00-06:46:00.log
capture_loss.06:48:00-06:49:00.log        files.06:44:00-06:45:00.log               stats.06:46:00-06:47:00.log
capture_loss.06:53:00-06:54:00.log        files.06:46:00-06:47:00.log               stats.06:47:00-06:48:00.log
cclink-ie-tsn-ptp.06:43:40-06:44:00.log   files.06:48:00-06:49:00.log               stats.06:50:00-06:51:00.log
cclink-ie-tsn-ptp.06:45:00-06:46:00.log   files.06:50:00-06:51:00.log               stats.06:51:00-06:52:00.log
cclink-ie-tsn-ptp.06:46:00-06:47:00.log   files.06:51:00-06:52:00.log               stats.06:52:00-06:53:00.log
cclink-ie-tsn-ptp.06:47:00-06:48:00.log   files.06:55:00-06:56:00.log               stats.06:55:00-06:56:00.log
cclink-ie-tsn-ptp.06:52:00-06:53:00.log   notice.06:17:00-06:18:00.log              stats.06:56:00-06:57:00.log
cclink-ie-tsn-ptp.06:53:00-06:54:00.log   notice.06:32:00-06:33:00.log              stderr.06:42:01-06:52:01.log
cclink-ie-tsn-slmp.06:43:22-06:44:00.log  notice.06:43:00-06:44:00.log              stdout.06:42:01-06:52:01.log
```
3.`find /usr/local/zeek/logs -name "*.log" -print0 | xargs -0 rm`は削除できるかどうかを確認
root@sensor:/usr/local/zeek/logs/2023-10-25# find /usr/local/zeek/logs -name "*.log" -print0 | xargs -0 rm
root@sensor:/usr/local/zeek/logs/2023-10-25# ls -l
total 0
root@sensor:/usr/local/zeek/logs/2023-10-25#
ログが削除できることを確認しました。 