### PR TITLE
update to ubuntu2204 in Dockerfile

### DIFF
--- a/osect_sensor/Application/edge_cron/edge_cron/urls.py
+++ b/osect_sensor/Application/edge_cron/edge_cron/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 

--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 As build-env
+FROM ubuntu:22.04 As build-env
 ENV LANG C.UTF-8
 ENV TZ Asia/Tokyo
 ENV DEBIAN_FRONTEND noninteractive
@@ -56,9 +56,9 @@ RUN apt-get update \
 # pip関係のインストール
 WORKDIR /home/work
 RUN apt-get purge -y python3-yaml \
-    && python3.8 -m pip install --upgrade pip --no-cache-dir \
-    && python3.8 -m pip install setuptools==59.8.0 --no-cache-dir \
-    && python3.8 -m pip install -r requirements.txt --no-cache-dir
+    && python3.10 -m pip install --upgrade pip --no-cache-dir \
+    && python3.10 -m pip install setuptools==59.8.0 --no-cache-dir \
+    && python3.10 -m pip install -r requirements.txt --no-cache-dir
 
 WORKDIR /home/work
 # Yafのインストール


### PR DESCRIPTION
close #158 
(このPRはgithub actionsでlintが失敗しましたので、issue #168 を立てました。actionsをpassするために、https://github.com/nttcom/OsecT/pull/170 を先にマージしてください。）

DockerfileでUbuntu22.04にアップデートしました。

テスト：
- ビルド
<img width="1421" alt="Screenshot 2024-01-30 at 15 49 10" src="https://github.com/nttcom/OsecT/assets/57517810/dd5a2be1-00de-41e7-a5d7-e163c592ff32">

- pushとimageの確認
<img width="1424" alt="Screenshot 2024-01-30 at 15 49 34" src="https://github.com/nttcom/OsecT/assets/57517810/0c7b54b5-9852-4051-beec-f9ce29bf44c6">

- センサーの構築 
<img width="919" alt="Screenshot 2024-01-30 at 16 10 13" src="https://github.com/nttcom/OsecT/assets/57517810/02c44c6d-a642-416d-abdd-35ea44d029f3">

- ログ送信の確認
<img width="984" alt="Screenshot 2024-01-30 at 16 19 15" src="https://github.com/nttcom/OsecT/assets/57517810/06c6a41e-e70c-416d-81f1-78124d482d7f">

- UI側にログの確認
<img width="854" alt="Screenshot 2024-01-30 at 16 19 01" src="https://github.com/nttcom/OsecT/assets/57517810/190d4f8b-f38b-491e-acbd-52e5831f6c95">

