### PR TITLE
#180 glibcのバージョン違いによりyafを実行できない問題を解消

### DIFF
--- a/osect_sensor/Infrastructure/edge_cron/Dockerfile
+++ b/osect_sensor/Infrastructure/edge_cron/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 As build-env
+FROM debian:bullseye-slim As build-env
 ENV LANG C.UTF-8
 ENV TZ Asia/Tokyo
 ENV DEBIAN_FRONTEND noninteractive
@@ -56,9 +56,9 @@ RUN apt-get update \
 # pip関係のインストール
 WORKDIR /home/work
 RUN apt-get purge -y python3-yaml \
-    && python3.10 -m pip install --upgrade pip --no-cache-dir \
-    && python3.10 -m pip install setuptools==59.8.0 --no-cache-dir \
-    && python3.10 -m pip install -r requirements.txt --no-cache-dir
+    && python3.9 -m pip install --upgrade pip --no-cache-dir \
+    && python3.9 -m pip install setuptools==59.8.0 --no-cache-dir \
+    && python3.9 -m pip install -r requirements.txt --no-cache-dir
 
 WORKDIR /home/work
 # Yafのインストール


### PR DESCRIPTION
close #180 

## 実装内容
zeekのベースイメージとビルド用イメージ(build-env)を揃えることにより、ビルド環境と実行環境のglibcのバージョンの差異を解消した。

なお、ベースイメージの変更に際し、Pythonのバージョンを3.10から3.9に変更した。

### 検証内容
各種ログ等が正常に生成されることを確認。

以下、確認したファイル（詳細はSlackへ）。
```
arp.log
cclink-ief-basic.log
cclink-ie.log
cclink-ie-tsn.log
cclink-ie-tsn-ptp.log
cclink-ie-tsn-slmp.log
conn.log
dhcp2.log
dhcpv6.log
dns.log
eve.json
http.log
mswin-browser.log
netbios-ns.log
ns.log
p0f-k.log
ssdp.log
yaf_flow.log
```