### PR TITLE
#138 ログ化機能・ログ送信機能の分離、及びNWアクセス制御

### DIFF
--- a/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
+++ b/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
@@ -16,6 +16,7 @@ from subprocess import Popen
 
 import requests
 import zstandard as zstd
+import serial
 from common.common_config import (
     ALLOWED_LOG_EXT,  # BACNET_SHELL_COMMAND,
     ALLOWED_PCAP_EXT,
@@ -146,7 +147,17 @@ class Command(BaseCommand):
         # logger.info("sleep " + str(sleep_time) + "s")
 
         try:
-            send_server(tar_list)
+            # コア網チェック
+            with serial.Serial('/dev/ttyUSB1', baudrate=115200, timeout=1) as sara:
+                sara.write(b'at\r\n')
+                b=sara.read(16)
+                cnum=b.decode().split("\n")
+
+            if "OK\r" in cnum:
+                # ログ送信
+                send_server(tar_list)
+            else:
+                logger.error("can not send compressed file. Unable to connect to closed network. ")
         except Exception as e:
             logger.error("can not send compressed file. " + str(e))
 

--- a/osect_sensor/Infrastructure/edge_cron/work/requirements.txt
+++ b/osect_sensor/Infrastructure/edge_cron/work/requirements.txt
@@ -4,3 +4,4 @@ meson==0.56.0
 requests==2.31.0
 urllib3==1.26.6
 zstandard==0.18.0
+pyserial==3.4

--- a/osect_sensor/docker-compose.yml
+++ b/osect_sensor/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   edge_cron:
     image: cron:revxxx
     build: "./Infrastructure/edge_cron/"
+    devices:
+      - "/dev/ttyUSB1:/dev/ttyUSB1"
     volumes:
       - ./Application/edge_cron:/opt/edge_cron
       - pcap-logs-volume:/opt/edge_cron/paper/sc_src/input/pcap/complete/


### PR DESCRIPTION
close #138

USBポートの確認方法（ttyUSB1に確定）
- 前田さんから抜き差しを確認。
```
sectu@sensor:~$ dmesg | grep -i usb
[ 1961.080274] usb 1-1: USB disconnect, device number 3
[ 1961.080708] option1 ttyUSB0: GSM modem (1-port) converter now disconnected from ttyUSB0
[ 1961.081032] option1 ttyUSB1: GSM modem (1-port) converter now disconnected from ttyUSB1
[ 1961.081392] option1 ttyUSB2: GSM modem (1-port) converter now disconnected from ttyUSB2
[ 1961.081663] option1 ttyUSB3: GSM modem (1-port) converter now disconnected from ttyUSB3
[ 1968.842578] usb 1-1: new high-speed USB device number 4 using xhci_hcd
[ 1969.002644] usb 1-1: New USB device found, idVendor=11f6, idProduct=1035, bcdDevice= 2.32
[ 1969.002650] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 1969.002653] usb 1-1: Product: NCXX UX302NC
[ 1969.002656] usb 1-1: Manufacturer: NCXX Inc.
[ 1969.002659] usb 1-1: SerialNumber: 1234567890
[ 1969.005723] usb-storage 1-1:1.0: USB Mass Storage device detected
[ 1969.006286] scsi host4: usb-storage 1-1:1.0
[ 1974.554516] usb 1-1: USB disconnect, device number 4
[ 1975.078507] usb 1-1: new high-speed USB device number 5 using xhci_hcd
[ 1975.238731] usb 1-1: New USB device found, idVendor=11f6, idProduct=1034, bcdDevice= 2.32
[ 1975.238737] usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 1975.238740] usb 1-1: Product: NCXX UX302NC
[ 1975.238743] usb 1-1: Manufacturer: NCXX Inc.
[ 1975.244194] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB0
[ 1975.244608] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB1
[ 1975.245062] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB2
[ 1975.245515] usb 1-1: GSM modem (1-port) converter now attached to ttyUSB3
```

- 村田さんからのドキュメントの確認。（1.2.2）
    - [資料](https://nttcomgroup.sharepoint.com/sites/data-device/SiteAssets/Forms/AllItems.aspx?id=%2Fsites%2Fdata%2Ddevice%2FSiteAssets%2FSitePages%2F%E9%96%8B%E7%99%BAOP2%2D1%E7%AE%A1%E7%90%86%E7%94%A8%2FUX302NC%2DR%5F3G%E5%81%9C%E6%B3%A2%E9%96%A2%E9%80%A3%2FSS020%2D053%5FUX302NC%2DR%5FAT%E3%82%B3%E3%83%9E%E3%83%B3%E3%83%89%E4%BB%95%E6%A7%98%E6%9B%B8%5FRev1%2E3%2Epdf&parent=%2Fsites%2Fdata%2Ddevice%2FSiteAssets%2FSitePages%2F%E9%96%8B%E7%99%BAOP2%2D1%E7%AE%A1%E7%90%86%E7%94%A8%2FUX302NC%2DR%5F3G%E5%81%9C%E6%B3%A2%E9%96%A2%E9%80%A3)

以下のついて確認をしました。
- ログ分離機能が必要なくなったので、ログ送信前の確認機能だけを実装。
- coe06とcomtest04のセンサーをデプロイしてテスト済み。
- 送信確認の文字列をOKから他の文字に変更し、送信しないことを確認。
```
sectu@sensor:~/osect_sensor/Application/edge_cron/cron/management/commands$ tail -f ~/osect_sensor/logs/ottools/edge_cron.log 
...
...
2024/06/05 21:30:06 [PID: 25911][Thread ID: 140079445624640][INFO][edge_cron] move analyzed log directory [/opt/edge_cron/paper/sc_src/input/pcap/analyze/realtime-2024-06-05-21:30:06]
2024/06/05 21:30:07 [PID: 25911][Thread ID: 140079445624640][ERROR][edge_cron] can not send compressed file. Unable to connect to closed network. 
2024/06/05 21:30:07 [PID: 25911][Thread ID: 140079445624640][INFO][edge_cron] end send compressed log ---Time:1.102846622467041(sec)---
2024/06/05 21:30:07 [PID: 25911][Thread ID: 140079445624640][INFO][edge_cron] pcap to log done
...
...
```
- 送信確認の文字列をOKに戻し、問題なく送信していないログをまとめて送信することを確認。
```
sectu@sensor:~/osect_sensor/Application/edge_cron/cron/management/commands$ tail -f ~/osect_sensor/logs/ottools/edge_cron.log 
...
...
2024/06/05 21:31:06 [PID: 26671][Thread ID: 139652222658368][INFO][edge_cron] move analyzed log directory [/opt/edge_cron/paper/sc_src/input/pcap/analyze/realtime-2024-06-05-21:31:06]
2024/06/05 21:31:08 [PID: 26671][Thread ID: 139652222658368][INFO][edge_cron] send compressed file: realtime-2024-06-05-21:30:06.tar.zst
2024/06/05 21:31:09 [PID: 26671][Thread ID: 139652222658368][INFO][edge_cron] send compressed file: realtime-2024-06-05-21:31:06.tar.zst
2024/06/05 21:31:09 [PID: 26671][Thread ID: 139652222658368][INFO][edge_cron] end send compressed log ---Time:2.3565711975097656(sec)---
2024/06/05 21:31:09 [PID: 26671][Thread ID: 139652222658368][INFO][edge_cron] pcap to log done
```