### PR TITLE
センサー一体型OsecTのファイル転送をHTTPからMVへ変換する実装

### DIFF
--- a/osect_sensor/Application/edge_cron/common/common_config.py
+++ b/osect_sensor/Application/edge_cron/common/common_config.py
@@ -1,5 +1,6 @@
 LABEL_ID = ""
 """ 複数スイッチ対応用のラベルID """
+""" せんさー一体型である場合はラベルネームを入力 """
 
 PCAP_UPLOADING_FILE_PATH = "paper/sc_src/input/pcap/uploading/"
 """pcapのアップロード先の配置パス"""
@@ -18,6 +19,9 @@ PCAP_COMPLETE_ARCHIVES_FILE_PATH = "paper/sc_src/input/pcap/complete_archives/"
 
 PCAP_SERVER_UPLOADING_FILE_PATH = "paper/sc_src/input/pcap/server_uploading/"
 """ ログ解析が終わったディレクトリをuploadするための一時領域 """
+
+PCAP_SERVER_UPLOADED_FILE_PATH = "paper/sc_src/input/pcap/server_uploaded"
+""" センサー一体型のコアのアップロード先 """
 
 SURICATA_ENABLE = True
 """ SURICATA使用フラグ（リアルタイム処理の場合はログを転送） """
@@ -89,3 +93,6 @@ SEND_REQUST_TIMEOUT = 180
 
 IS_CLOSED_NETWORK = True
 """ モバイル経由のフラグ """
+
+SENSOR_INTEGRATED_TYPE = False
+""" センサー一体型のフラグ """

--- a/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
+++ b/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
@@ -48,6 +48,8 @@ from common.common_config import (
     LABEL_ID,
     CLIENT_CERTIFICATE_PATH,
     IS_CLOSED_NETWORK,
+    SENSOR_INTEGRATED_TYPE,
+    PCAP_SERVER_UPLOADED_FILE_PATH
 )
 
 # from common.common_function import pcap2log
@@ -164,7 +166,10 @@ class Command(BaseCommand):
                     )
             else:
                 # ログ送信
-                send_server(tar_list)
+                if SENSOR_INTEGRATED_TYPE:
+                    move_server(tar_list)
+                else:
+                    send_server(tar_list)
         except Exception as e:
             logger.error("can not send compressed file. " + str(e))
 
@@ -405,3 +410,17 @@ def send_server(zip_list):
         logger.info("send compressed file: " + file_name)
         # ファイルが正常に送信できた場合は、tar.zstファイルを削除する
         os.remove(zip_file)
+
+def move_server(zip_list):
+    """
+    ログファイルをサーバーに送付する。
+    :param zip_list: 送付対象のtar.zstファイルのlist
+    """
+
+    for zip_file in zip_list:
+        file_name = os.path.basename(zip_file)
+        move_path = os.path.join(PCAP_SERVER_UPLOADED_FILE_PATH, LABEL_ID)
+        os.makedirs(move_path, exist_ok=True)
+        shutil.move(zip_file, move_path)
+
+        logger.info("send compressed file: " + file_name)

--- a/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
+++ b/osect_sensor/Application/edge_cron/cron/management/commands/pcap_to_log_to_server.py
@@ -49,7 +49,7 @@ from common.common_config import (
     CLIENT_CERTIFICATE_PATH,
     IS_CLOSED_NETWORK,
     SENSOR_INTEGRATED_TYPE,
-    PCAP_SERVER_UPLOADED_FILE_PATH
+    PCAP_SERVER_UPLOADED_FILE_PATH,
 )
 
 # from common.common_function import pcap2log
@@ -410,6 +410,7 @@ def send_server(zip_list):
         logger.info("send compressed file: " + file_name)
         # ファイルが正常に送信できた場合は、tar.zstファイルを削除する
         os.remove(zip_file)
+
 
 def move_server(zip_list):
     """

--- a/osect_sensor/README.md
+++ b/osect_sensor/README.md
@@ -236,6 +236,56 @@ $ vi docker-compose.yml
 （削除）
 ```
 
+センサー一体型OsecTの場合は以下の設定をします。
+
+```bash
+$ vi Application/edge_cron/common/common_config.py
+```
+
+変更箇所:
+
+```python
+# センサー一体型のフラグ False
+SENSOR_INTEGRATED_TYPE = False
+↓
+# センサー一体型のフラグ True
+SENSOR_INTEGRATED_TYPE = True
+```
+
+設定ファイル:
+
+```bash
+$ vi docker-compose.yml
+```
+
+変更箇所:
+
+```yml
+    volumes:
+      ...
+      ...
+      - ./conf/local.zeek:/usr/local/zeek/share/zeek/site/local.zeek # zeek realtime
+↓
+    volumes:
+      ...
+      ...
+      - ./conf/local.zeek:/usr/local/zeek/share/zeek/site/local.zeek # zeek realtime
+      - ~/edgesec_on_docker/logs/pcap/uploaded:/opt/edge_cron/paper/sc_src/input/pcap/server_uploaded # multiport
+```
+
+（参考）
+
+センサー一体型OsecTである場合の```Application/edge_cron/common/common_config.py```の```LABEL_ID```設定は```label_name```を設定することです。
+
+```
+common_db=# select * from label_master;
+ id | label_id | label_name | label_display_name 
+----+----------+------------+--------------------
+  1 | sensor1（ここを指定するではなく）  | default（ここを指定する）    | デフォルト
+  2 | sensor2（ここを指定するではなく）  | sensor_1（ここを指定する）   | センサー１
+(2 rows)
+```
+
 ## 4. コンテナの構築・起動
 
 コンテナを構築、起動します。


### PR DESCRIPTION
「http -> ファイルの移動」の変更が以下の仕組みで実装。

- コア側の転送先（~/edgesec_on_docker/logs/pcap/uploaded）をセンサー側にマウント。
  - ~~この修正は普通のsaas版のセンサーが不要なので、SOツールで対応する予定です。~~
  - READMEの「3.5. ログ送信方式の設定」部分に手動で設定するように追記。
```
    volumes:
      - ~/edgesec_on_docker/logs/pcap/uploaded:/opt/edge_cron/paper/sc_src/input/pcap/server_uploaded
```

- センサー側に以下の環境変数を追加。
```
PCAP_SERVER_UPLOADED_FILE_PATH = "paper/sc_src/input/pcap/server_uploaded"
""" センサー一体型のコアのアップロード先 """

SENSOR_INTEGRATED_TYPE = True
""" センサー一体型のフラグ """
```

- センサー側にsend_server(zip_list)と同様にmove_server(zip_list)を作成。
- センサー送信時にセンサー一体型OsecTであるかどうか（SENSOR_INTEGRATED_TYPE）を判定。
  - True：send_server(zip_list)
  - False：send_server(zip_list)

構築時の注意点は以下です。（README「3.5. ログ送信方式の設定」部分に追記）
- saas型はラベルIDをセンサーから取得し、コア側のDBを参照しラベルネームを取得しています。
- センサー一体型OsecTである場合は、センサーがコアのDBにアクセスできないので、ラベルIDを直接ラベルネームに指定する。
```
common_db=# select * from label_master;
 id | label_id | label_name | label_display_name 
----+----------+------------+--------------------
  1 | sensor1（ここを指定するではなく）  | default（ここを指定する）    | デフォルト
  2 | sensor2（ここを指定するではなく）  | sensor_1（ここを指定する）   | センサー１
(2 rows)
```

以下のテストをしました。
- SENSOR_INTEGRATED_TYPE = False  & LABEL_ID = label_id の場合が正常にデータを送信できることを確認。（SAAS版に影響がないかの確認）
<img width="933" alt="SENSOR_INTEGRATED_TYPE_False_sensor_1" src="https://github.com/user-attachments/assets/0f5acbf8-e263-4224-9e2f-d70e7ceb10af">
<img width="1158" alt="SENSOR_INTEGRATED_TYPE_False_default" src="https://github.com/user-attachments/assets/c5a196ed-0d75-491e-a7ea-7ead132f7fb0">

- SENSOR_INTEGRATED_TYPE = True  & LABEL_ID = label_name の場合が正常にデータを送信できることを確認。（修正後が正しく転送されていることを確認）
<img width="1055" alt="SENSOR_INTEGRATED_TYPE_True_sensor_1" src="https://github.com/user-attachments/assets/cfad02ce-4901-42e8-aa2d-22ad97ee5efd">
<img width="973" alt="SENSOR_INTEGRATED_TYPE_True_default" src="https://github.com/user-attachments/assets/d7f6ffa3-b750-4fff-bb16-d4c46788d367">
